### PR TITLE
change default behavior from stopOnError=True to stopOnError=False

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -709,7 +709,7 @@ class Plugin(object):
             self._engine.log.critical('Did not find a registerCallbacks function in plugin at %s.', self._path)
             self._active = False
 
-    def registerCallback(self, sgScriptName, sgScriptKey, callback, matchEvents=None, args=None, stopOnError=True):
+    def registerCallback(self, sgScriptName, sgScriptKey, callback, matchEvents=None, args=None, stopOnError=False):
         """
         Register a callback in the plugin.
         """


### PR DESCRIPTION
Hey KP, by default the daemon stops processing all events for a plugin if that plugin encounters an error processing a single event. The only way to get it processing events again is to restart the daemon or update the timestamp on the plugin.

This patch changes the default behavior such that events continue to process. Hopefully this saves others from pulling out their hair in frustration when their plugin mysteriously stops processing events on a regular basis. :-)

cheers
