### PR TITLE
Automatically use script name/key from config file

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -714,6 +714,10 @@ class Plugin(object):
         Register a callback in the plugin.
         """
         global sg
+
+        sgScriptName = sgScriptName or self._engine.config.getEngineScriptName()
+        sgScriptKey = sgScriptKey or self._engine.config.getEngineScriptKey()
+
         sgConnection = sg.Shotgun(self._engine.config.getShotgunURL(), sgScriptName, sgScriptKey)
         self._callbacks.append(Callback(callback, self, self._engine, sgConnection, matchEvents, args, stopOnError))
 


### PR DESCRIPTION
This patch allows a user to leave the script name/key arguments empty in registerCallback, which will make the events framework automatically use the name/key from the shotgunEventsDaemon.conf file.
