### PR TITLE
Allow plugin paths to be relative to shotgunEventDaemon.py

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -150,7 +150,12 @@ class Config(ConfigParser.ConfigParser):
         return self.get('daemon', 'pidFile')
 
     def getPluginPaths(self):
-        return [s.strip() for s in self.get('plugins', 'paths').split(',')]
+        pluginPaths = []
+        root = os.path.dirname(__file__)
+        for s in self.get('plugins', 'paths').split(','):
+            pluginPath = os.path.normpath(os.path.join(root, s))
+            pluginPaths.append(pluginPath)
+        return pluginPaths
 
     def getSMTPServer(self):
         return self.get('emails', 'server')


### PR DESCRIPTION
This patch allows plugin paths to be relative rather than absolute.
