### PR TITLE
Speeding up the daemon when it's been down for some time

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -448,7 +448,7 @@ class Engine(object):
 
         if nextEventId is not None:
             filters = [['id', 'greater_than', nextEventId - 1]]
-            fields = ['id', 'event_type', 'attribute_name', 'meta', 'entity', 'user', 'project', 'session_uuid']
+            fields = ['id', 'event_type', 'attribute_name', 'meta', 'entity', 'user', 'project', 'session_uuid', 'created_at']
             order = [{'column':'id', 'direction':'asc'}]
     
             conn_attempts = 0
@@ -726,13 +726,13 @@ class Plugin(object):
             if self._process(event):
                 self.logger.info('Processed id %d from backlog.' % event['id'])
                 del(self._backlog[event['id']])
-                self._updateLastEventId(event['id'])
+                self._updateLastEventId(event)
         elif self._lastEventId is not None and event['id'] <= self._lastEventId:
             msg = 'Event %d is too old. Last event processed was (%d).'
             self.logger.debug(msg, event['id'], self._lastEventId)
         else:
             if self._process(event):
-                self._updateLastEventId(event['id'])
+                self._updateLastEventId(event)
 
         return self._active
 
@@ -753,13 +753,26 @@ class Plugin(object):
 
         return self._active
 
-    def _updateLastEventId(self, eventId):
-        if self._lastEventId is not None and eventId > self._lastEventId + 1:
-            expiration = datetime.datetime.now() + datetime.timedelta(minutes=5)
-            for skippedId in range(self._lastEventId + 1, eventId):
-                self.logger.info('Adding event id %d to backlog.', skippedId)
-                self._backlog[skippedId] = expiration
-        self._lastEventId = eventId
+    def _updateLastEventId(self, event):
+        BACKLOG_TIMEOUT = 5 # time in minutes after which we consider a pending event won't happen
+        if self._lastEventId is not None and event["id"] > self._lastEventId + 1:
+            event_date = event["created_at"].replace(tzinfo=None)
+            if datetime.datetime.now() > (event_date + datetime.timedelta(minutes=BACKLOG_TIMEOUT)):
+                # the event we've just processed happened more than BACKLOG_TIMEOUT minutes ago so any event
+                # with a lower id should have shown up in the EventLog by now if it actually happened
+                if event["id"]==self._lastEventId+2:
+                    self.logger.info('Event %d never happened - ignoring.', self._lastEventId+1)
+                else:
+                    self.logger.info('Events %d-%d never happened - ignoring.', self._lastEventId+1, event["id"]-1)
+            else:
+                # in this case, we want to add the missing events to the backlog as they could show up in the
+                # EventLog within BACKLOG_TIMEOUT minutes, during which we'll keep asking for the same range
+                # them to show up until they expire
+                expiration = datetime.datetime.now() + datetime.timedelta(minutes=BACKLOG_TIMEOUT)
+                for skippedId in range(self._lastEventId + 1, event["id"]):
+                    self.logger.info('Adding event id %d to backlog.', skippedId)
+                    self._backlog[skippedId] = expiration
+        self._lastEventId = event["id"]
 
     def __iter__(self):
         """


### PR DESCRIPTION
When the daemon has been down or couldn't access Shotgun for some time (for whatever reason), the daemon is really slow to catch up with all the events it missed.

There are two causes to this, each addressed by one commit in this pull request:

1. Between each call to _getNewEvents(), the daemon waits a few seconds. This is useful when the daemon is up-to-date with Shotgun, so it doesn't flood the server with queries. But when it's lagging behind, there's no reason to wait between queries. 
=> I remove the call to time.sleep() when the batch of events we received is a full one.

2. The backlog feature is used to allow for long transactions to complete. The daemon detects any gap in the EventLog, and then wait for 5 minutes for the missing events to eventually show up, by constantly querying the same range of events until the missing events appear or the time limit is reached. When processing old events (eg. 2 days old), it's easy to see that it's useless to wait 5 minutes for the missing events to show up (they should have appeared 2 days ago).
=> the creation date of the EventLogEntry is now retrieved. When we process an event, if it happened more than 5 minutes ago, then we can safely know that events with a lower id should have shown up by now, so we ignore the gap and don't add the ids to the backlog.

When processing several days of events, the second problem often delays the daemon by several hours before it catches up with the server.