### PR TITLE
Handle existing .id file collection path mismatches

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -366,13 +366,13 @@ class Engine(object):
                                 else:
                                     maxPluginStates[pluginName] = pluginState
 
+                        lastEventId = self._getLastEventIdFromDatabase()
                         for collection in noStateCollections:
                             state = collection.getState()
                             for pluginName in state.keys():
                                 if pluginName in maxPluginStates.keys():
                                     state[pluginName] = maxPluginStates[pluginName]
                                 else:
-                                    lastEventId = self._getLastEventIdFromDatabase()
                                     state[pluginName][0] = latestEventId
                             collection.setState(state)
 

--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -361,7 +361,7 @@ class Engine(object):
                         for collection in self._eventIdData.values():
                             for pluginName, pluginState in collection.items():
                                 if pluginName in maxPluginStates.keys():
-                                    if v[0] > maxPluginStates[k][0]:
+                                    if pluginState[0] > maxPluginStates[pluginName][0]:
                                         maxPluginStates[pluginName] = pluginState
                                 else:
                                     maxPluginStates[pluginName] = pluginState
@@ -369,7 +369,7 @@ class Engine(object):
                         for collection in noStateCollections:
                             state = collection.getState()
                             for pluginName in state.keys():
-                                if pluginName in maxPluginStates:
+                                if pluginName in maxPluginStates.keys():
                                     state[pluginName] = maxPluginStates[pluginName]
                                 else:
                                     lastEventId = self._getLastEventIdFromDatabase()


### PR DESCRIPTION
Adding a clause that gets called if there's a .id file that already exists, but any of the plugin paths specified in the .conf are not being tracked there. At present a plugin collection will get skipped entirely in this case.

This becomes an issue in 2 cases:
1) An additional plugins path is added after the system has been started at least once.
2) The plugins directory gets moved to a new location. Even if the conf is updated properly it won't match up to the .id file, and so the plugins will never get executed.