### PR TITLE
Update statusFlipDownstreamTasks.py

### DIFF
--- a/src/examplePlugins/statusFlipDownstreamTasks.py
+++ b/src/examplePlugins/statusFlipDownstreamTasks.py
@@ -17,8 +17,8 @@ def registerCallbacks(reg):
 def flipDownstreamTasks(sg, logger, event, args):
     """Flip downstream Tasks to 'rdy' if all of their upstream Tasks are 'fin'"""
     
-    # we only care about Tasks that have been finalled
-    if 'new_value' not in event['meta'] or event['meta']['new_value'] != 'fin':
+    # we only care about Tasks that have been finalled, and skip events where entity field is empty
+    if 'new_value' not in event['meta'] or event['meta']['new_value'] != 'fin' or event['entity'] is None:
         return
     
     # downtream tasks that are currently wtg


### PR DESCRIPTION
Added an additional check on line 21 to see if the entity field is empty. This can happen when a Task is changed, then *immediately* retired, which can then lead to this plugin changing *all* Tasks with an empty upstream_dependency field to "Rdy."