### PR TITLE
Fixes misnamed variable.

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -373,7 +373,7 @@ class Engine(object):
                                 if pluginName in maxPluginStates.keys():
                                     state[pluginName] = maxPluginStates[pluginName]
                                 else:
-                                    state[pluginName][0] = latestEventId
+                                    state[pluginName][0] = lastEventId
                             collection.setState(state)
 
                 except pickle.UnpicklingError:


### PR DESCRIPTION
`lastestEventId` isn't a valid variable, assuming this was supposed to be `lastEventId`.