### PR TITLE
Fix missing attribute `logger` in an example file.

### DIFF
--- a/src/examplePlugins/calc_summaries.py
+++ b/src/examplePlugins/calc_summaries.py
@@ -240,7 +240,7 @@ def is_valid(sg, logger, args):
     return True
 
 
-def check_entity_schema(sg, entity_type, field_name, field_type=None):
+def check_entity_schema(sg, logger, entity_type, field_name, field_type=None):
     """
     Verifies that field_name of field_type exists in entity_type's schema.
 


### PR DESCRIPTION
There was a missing logger attribute in the `calc_summaries.py` example file.