### PR TITLE
Add environment variable support in config

### DIFF
--- a/src/shotgunEventDaemon.conf.example
+++ b/src/shotgunEventDaemon.conf.example
@@ -66,14 +66,14 @@ max_event_batch_size = 500
 # Shotgun connection options for the daemon
 
 # The Shotgun url the event processing framework should connect to.
-server: https://yoursite.shotgunstudio.com
+server: %(SG_ED_SITE_URL)s
 
 # The Shotgun script name the framework should connect with.
-name: shotgunEventDaemon
+name: %(SG_ED_SCRIPT_NAME)s
 
 # The Shotgun api key the framework should connect with. You'll need to replace
 # this random useless key with the one corresponding to the script you've setup.
-key: 841c9a51bf45e1872c3e5f2435dade67458bc858
+key: %(SG_ED_API_KEY)s
 
 # The address of the proxy server used to connect to your Shotgun server
 # in the format 111.222.333.444:8080. Leave this empty if you don't have
@@ -113,8 +113,8 @@ paths: /usr/local/shotgun/plugins
 server: smtp.yourdomain.com
 #port: 587
 #useTLS: True
-#username: yourSMTPUsername
-#password: yourSMPTPassword
+#username: %(SG_ED_EMAIL_USERNAME)s
+#password: %(SG_ED_EMAIL_PASSWORD)s
 
 # The from address that should be used in emails.
 from: support@yourdomain.com

--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -25,8 +25,8 @@ http://shotgunsoftware.github.com/shotgunEvents
 
 from __future__ import print_function
 
-__version__ = "0.9"
-__version_info__ = (0, 9)
+__version__ = "1.0"
+__version_info__ = (1, 0)
 
 # Suppress the deprecation warning about imp until we get around to replacing it
 import warnings
@@ -149,9 +149,9 @@ def _addMailHandlerToLogger(
         logger.addHandler(mailHandler)
 
 
-class Config(configparser.ConfigParser):
+class Config(configparser.SafeConfigParser):
     def __init__(self, path):
-        configparser.ConfigParser.__init__(self)
+        configparser.SafeConfigParser.__init__(self, os.environ)
         self.read(path)
 
     def getShotgunURL(self):
@@ -366,7 +366,7 @@ class Engine(object):
         socket.setdefaulttimeout(60)
 
         # Notify which version of shotgun api we are using
-        self.log.info("Using Shotgun version %s" % sg.__version__)
+        self.log.info("Using Shotgun Python API version %s" % sg.__version__)
 
         try:
             for collection in self._pluginCollections:


### PR DESCRIPTION
PR adds environment variable support in the config file as well as using environment variables in the example config file in order to specify the Shotgun site's URL, the script name and script key as well as email username and password.

The PR also clarifies a status message and _finally_ bumps version to 1.0.