### PR TITLE
Fixes an issue on Python3 with our stderr redirecting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Fx](http://rodeofx.com) and [Oblique](http://obliquefx.com). It is now part of
 initiative](https://github.com/shotgunsoftware).
 
 This software is provided under the MIT License that can be found in the LICENSE
-file or at the [Open Source Initiative](http://www.opensource.org/licenses/mit-
-license.php) website.
+file or at the [Open Source Initiative](http://www.opensource.org/licenses/mit-license.php) website.
 
 
 ## Overview

--- a/src/daemonizer.py
+++ b/src/daemonizer.py
@@ -66,8 +66,8 @@ class Daemon(object):
             sys.stderr.write("fork #2 failed: %d (%s)\n" % (e.errno, e.strerror))
             sys.exit(1)
 
-        # redirect standard file descriptors
-        # unless specified when instantiating the class the will
+        # redirect standard file descriptors.
+        # Unless specified when instantiating the class, it will
         # by default redirect the stdin, stdout, stderr to a null file
         # which is the equivalent of discarding the output.
         sys.stdout.flush()

--- a/src/daemonizer.py
+++ b/src/daemonizer.py
@@ -67,11 +67,14 @@ class Daemon(object):
             sys.exit(1)
 
         # redirect standard file descriptors
+        # unless specified when instantiating the class the will
+        # by default redirect the stdin, stdout, stderr to a null file
+        # which is the equivalent of discarding the output.
         sys.stdout.flush()
         sys.stderr.flush()
         si = open(self._stdin, "r")
         so = open(self._stdout, "a+")
-        se = open(self._stderr, "a+", 0)
+        se = open(self._stderr, "a+b", 0)
         os.dup2(si.fileno(), sys.stdin.fileno())
         os.dup2(so.fileno(), sys.stdout.fileno())
         os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
I'm unsure if this is the right fix or not.

I understand that in Python 2, doing 

```python
se = open("/my_file.txt", "a+", 0)
se.write("hi")
import time
time.sleep(15)
```

Would mean that the "hi" text would be written to the file before the script ended without a flush because we provided the `0`  unbuffered argument.
However in Python 3 this is only available for binary objects. So you can use the following instead:

```python
se = open("/my_file.txt", "a+b", 0)
```

This would cause an error with the original script because we are passing a string, but if we did:
```python
import os, sys

stderr = "/test.txt"
se = open(stderr, "a+b", 0)
os.dup2(se.fileno(), sys.stderr.fileno())

a = 8/0
```
That actually is fine and the error is written to the file. I'm unsure why that is OK when an error is generated, I presume it is being converted to a binary? 
But also I'm not sure of the importance here of setting the buffer to 0 on an error, presumably it will be flushed as soon as it errors since the program will stop? And even if it didn't then is it important since we are from what I can tell discarding it anyway?

So perhaps this would be fine instead?

```python
se = open("/my_file.txt", "a+")
```