### PR TITLE
SG-15664 Replace `imp`

### DIFF
--- a/src/examplePlugins/datestamp.py
+++ b/src/examplePlugins/datestamp.py
@@ -279,7 +279,10 @@ def get_date_or_timestamp(logger, sg, event, entity_type, date_field, timezone):
 
     # Determine the date field type of date_field.
     if date_field and timezone:
-        date_field_type = sg.schema_field_read(entity_type, date_field,)[date_field][
+        date_field_type = sg.schema_field_read(
+            entity_type,
+            date_field,
+        )[date_field][
             "data_type"
         ]["value"]
 

--- a/src/examplePlugins/version_finaled.py
+++ b/src/examplePlugins/version_finaled.py
@@ -221,9 +221,9 @@ def version_finaled(sg, logger, event, args):
                         version_date_or_timestamp
                         and not other_version[args["version_date_field"]]
                     ):
-                        update_dict[
-                            args["version_date_field"]
-                        ] = version_date_or_timestamp
+                        update_dict[args["version_date_field"]] = (
+                            version_date_or_timestamp
+                        )
                     batch_data.append(
                         {
                             "request_type": "update",
@@ -268,7 +268,10 @@ def get_date_or_timestamp(logger, sg, event, entity_type, date_field, timezone):
 
     # Determine the date field type of date_field.
     if date_field and timezone:
-        date_field_type = sg.schema_field_read(entity_type, date_field,)[date_field][
+        date_field_type = sg.schema_field_read(
+            entity_type,
+            date_field,
+        )[date_field][
             "data_type"
         ]["value"]
 

--- a/src/importlib_wrapper.py
+++ b/src/importlib_wrapper.py
@@ -9,6 +9,7 @@ import importlib.util
 import importlib.machinery
 from types import ModuleType
 
+
 def load_source(modname: str, filename: str) -> ModuleType:
     loader = importlib.machinery.SourceFileLoader(modname, filename)
     spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)

--- a/src/importlib_wrapper.py
+++ b/src/importlib_wrapper.py
@@ -1,0 +1,20 @@
+# Importlib wrapper for Python 3.11- compatibility.
+# This module provides a function to load a source file as a module,
+# mimicking the behavior of the `imp.load_source()` function.
+# It is intended to be used in environments where the `imp` module is deprecated
+# or removed, such as in Python 3.12 and later.
+# Taken from https://docs.python.org/3/whatsnew/3.12.html#imp
+
+import importlib.util
+import importlib.machinery
+from types import ModuleType
+
+def load_source(modname: str, filename: str) -> ModuleType:
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module

--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -28,13 +28,6 @@ from __future__ import print_function
 __version__ = "1.0"
 __version_info__ = (1, 0)
 
-# Suppress the deprecation warning about imp until we get around to replacing it
-import warnings
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    import imp
-
 import datetime
 import logging
 import logging.handlers
@@ -58,6 +51,8 @@ if sys.platform == "win32":
 import daemonizer
 import shotgun_api3 as sg
 from shotgun_api3.lib.sgtimezone import SgTimezone
+
+import importlib_wrapper
 
 
 SG_TIMEZONE = SgTimezone()
@@ -835,7 +830,7 @@ class Plugin(object):
         self._active = True
 
         try:
-            plugin = imp.load_source(self._pluginName, self._path)
+            plugin = importlib_wrapper.load_source(self._pluginName, self._path)
         except:
             self._active = False
             self.logger.error(

--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -40,8 +40,6 @@ import traceback
 import configparser
 import pickle
 
-from distutils.version import StrictVersion
-
 if sys.platform == "win32":
     import win32serviceutil
     import win32service


### PR DESCRIPTION
This pull request replaces the deprecated `imp` module with a custom `importlib_wrapper` to ensure compatibility with Python 3.12 and later. The changes include introducing the wrapper, updating the plugin loading mechanism, and removing deprecation warning suppression for `imp`.