### PR TITLE
Fix broken email notification in python-3.12

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -37,6 +37,7 @@ import time
 import traceback
 import configparser
 import pickle
+import ssl
 
 if sys.platform == "win32":
     import win32serviceutil
@@ -1218,7 +1219,7 @@ class CustomSMTPHandler(logging.handlers.SMTPHandler):
             if self.username:
                 if self.secure is not None:
                     smtp.ehlo()
-                    smtp.starttls(*self.secure)
+                    smtp.starttls(context=ssl.create_default_context())
                     smtp.ehlo()
                 smtp.login(self.username, self.password)
             smtp.sendmail(self.fromaddr, self.toaddrs, msg)


### PR DESCRIPTION
In Python 3.12, they removed the keyfile and certfile parameters in smtp.starttls().
https://docs.python.org/3.12/library/smtplib.html#smtplib.SMTP.starttls

This PR changes the parameters to a context which was introduced in Python 3.3.

This makes email notifications work again in Python 3.12.